### PR TITLE
Set series name if empty

### DIFF
--- a/pwclient-save-series.py
+++ b/pwclient-save-series.py
@@ -160,6 +160,9 @@ def save_series(url, project_name, patch_state, dest_path, exclude_str=None,
         os.mkdir(save_path)
 
     for item in series:
+        if item["name"] == None:
+            item["name"] = "Untitled series of #{}".format(item["id"])
+
         print("Series Name: %s" % item["name"])
 
         if exclude_str != None:


### PR DESCRIPTION
This patch checks the series name and set to defaul name if the series
name is empry for some reason.