### PR TITLE
entrypoint.sh: Enable ignore_check option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,4 +47,4 @@ echo "HUB_PROTOCOL=$HUB_PROTOCOL"
 echo "GITHUB_USER=$GITHUB_USER"
 
 echo "########## RUN ##########"
-/pw-to-pr.py -c /config.json -r $GITHUB_REPOSITORY -b $BASE_BRANCH -k $PW_KEY_STR -s $PWD
+/pw-to-pr.py -c /config.json -r $GITHUB_REPOSITORY -b $BASE_BRANCH -k $PW_KEY_STR -s $PWD -i


### PR DESCRIPTION
This patch enables the ignore_check option so the CI can re-run when PR doesn't exist even if it was already checked before.